### PR TITLE
fix: Make IDs copyable in admin tables

### DIFF
--- a/src/app/connects/page.tsx
+++ b/src/app/connects/page.tsx
@@ -16,6 +16,7 @@ const customTableProps: TableProps = {
       fieldName: "userId",
       type: FieldType.LONGTEXT,
       wordsCnt: 20,
+      copyable: true,
     },
     {
       textValue: "User Type",

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -14,12 +14,14 @@ const customTableProps: TableProps = {
       fieldName: "from",
       type: FieldType.LONGTEXT,
       wordsCnt: 20,
+      copyable: true,
     },
     {
       textValue: "To",
       fieldName: "to",
       type: FieldType.LONGTEXT,
       wordsCnt: 20,
+      copyable: true,
     },
     {
       textValue: "Amount",
@@ -46,6 +48,7 @@ const customTableProps: TableProps = {
       fieldName: "reference_id",
       type: FieldType.LONGTEXT,
       wordsCnt: 10,
+      copyable: true,
     },
     {
       textValue: "Created At",

--- a/src/components/connects/ConnectsDetails.tsx
+++ b/src/components/connects/ConnectsDetails.tsx
@@ -61,6 +61,14 @@ export const ConnectsDetails = ({
     }
   };
 
+  const handleCopy = async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    toast({
+      title: "Copied",
+      description: "User ID copied to clipboard",
+    });
+  };
+
   const dialogContent = (
     <div className="flex flex-col space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -68,12 +76,23 @@ export const ConnectsDetails = ({
           <p className="font-semibold text-sm text-gray-500 dark:text-gray-400">
             User ID
           </p>
-          <Link
-            href={`/users/view?id=${data.userId}`}
-            className="font-mono text-base mt-1 text-blue-600 hover:underline dark:text-blue-400 break-all"
-          >
-            {data.userId}
-          </Link>
+          <div className="flex flex-col gap-1 mt-1">
+  <span
+    onClick={() => handleCopy(data.userId)}
+    title="Click to copy User ID"
+    className="font-mono text-base text-blue-600 hover:underline cursor-pointer break-all"
+  >
+    {data.userId}
+  </span>
+
+  <Link
+    href={`/users/view?id=${data.userId}`}
+    className="text-xs text-gray-500 hover:underline"
+  >
+    View user profile →
+  </Link>
+</div>
+
         </div>
         <div>
           <p className="font-semibold text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/custom-table/FieldComponents.tsx
+++ b/src/components/custom-table/FieldComponents.tsx
@@ -20,6 +20,7 @@ import { DotsVerticalIcon } from "@radix-ui/react-icons";
 import { twMerge } from "tailwind-merge";
 import { ToolTip } from "../ToolTip";
 import { cn } from "@/lib/utils";
+import { useToast } from "../ui/use-toast";
 
 // Single source of truth for both solid and outline styles
 type StatusStyle = { solid: string; outline: string };
@@ -436,28 +437,44 @@ export const TooltipField = ({
 };
 
 const LongTextField = ({ fieldData, value }: FieldComponentProps<string>) => {
+  const { toast } = useToast();
+
   if (!value) return <span>-</span>;
-  if (fieldData.wordsCnt && value.length <= fieldData.wordsCnt)
-    return <span>{value}</span>;
 
-  if (fieldData.wordsCnt)
-    return (
-      <ToolTip
-        trigger={
-          <span className=" line-clamp-1">
-            {value.slice(0, fieldData.wordsCnt)}...
-          </span>
-        }
-        content={value || ""}
-      />
-    );
+  const isCopyable = fieldData.copyable === true;
 
-  return (
-    <ToolTip
-      trigger={<span className=" line-clamp-1">{value}</span>}
-      content={value || ""}
-    />
+  const displayValue =
+    fieldData.wordsCnt && value.length > fieldData.wordsCnt
+      ? `${value.slice(0, fieldData.wordsCnt)}...`
+      : value;
+
+  const handleCopy = async () => {
+    if (!isCopyable) return;
+    await navigator.clipboard.writeText(value);
+    toast({
+      title: "Copied",
+      description: "User ID Copied to clipboard",
+    });
+  };
+
+  const content = (
+    <span
+      className={cn(
+        "line-clamp-1",
+        isCopyable && "cursor-pointer text-blue-600 hover:underline"
+      )}
+      title={isCopyable ? "Click to copy" : undefined}
+      onClick={isCopyable ? handleCopy : undefined}
+    >
+      {displayValue}
+    </span>
   );
+
+  if (fieldData.wordsCnt && value.length > fieldData.wordsCnt) {
+    return <ToolTip trigger={content} content={value} />;
+  }
+
+  return content;
 };
 
 const CustomComponent = ({

--- a/src/components/custom-table/FieldTypes.ts
+++ b/src/components/custom-table/FieldTypes.ts
@@ -57,6 +57,7 @@ export interface Field {
   formating?: object;
   link?: string; // the placeholder link to be displayed if type === FieldType.LINK
   tooltip?: boolean;
+  copyable?: boolean;
   tooltipContent?: string; // tooltip content to be displayed if tooltip === true
   className?: string; // custom tailwind classes to be added to the table cell
   arrayName?: string; // the key in the api response if type === FieldType.ARRAY_VALUE and the value is an array of objects than  array of strings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality for key table columns: User ID (Connects), From/To addresses, and Reference ID (Transactions). Users can now click to copy these values.
  * Added toast notifications confirming successful copy actions.
  * Added "View user profile" link in details view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->